### PR TITLE
Create Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,6 @@
+# Docker image for tn93
+FROM ubuntu:20.04
+
+# Set up environment and install dependencies
+RUN apt-get update && apt-get -y upgrade && \
+    DEBIAN_FRONTEND=noninteractive TZ=Etc/UTC apt-get install -y cmake g++ git make


### PR DESCRIPTION
I created a `Dockerfile` that goes from a base Ubuntu 20.04 image to a fully-configured environment that can clone, compile, and run `tn93` (I tested it).