### PR TITLE
Fixed Dockerfile GCC version

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,8 @@ FROM oraclelinux:8
 # Set up environment and install dependencies
 RUN yum -y update && \
     yum install -y cmake gcc-c++ gcc-toolset-10 git make oracle-epel-release-el8 && \
-    echo 'source /opt/rh/gcc-toolset-10/enable' > ~/.bashrc
+    echo 'source /opt/rh/gcc-toolset-10/enable' > ~/.bashrc && \
+    source ~/.bashrc
 
 # To compile tn93 within the development environment:
 #   cmake .

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,6 +4,7 @@ FROM oraclelinux:8
 # Set up environment and install dependencies
 RUN yum -y update && \
     yum install -y cmake gcc-c++ gcc-toolset-10 git make oracle-epel-release-el8 && \
+    rm -f CMakeCache.txt && \
     scl enable gcc-toolset-10 bash
 
 # To compile tn93 within the development environment:

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,8 @@ FROM oraclelinux:8
 
 # Set up environment and install dependencies
 RUN yum -y update && \
-    yum install -y cmake gcc-c++ git make
+    yum install -y cmake gcc-c++ gcc-toolset-10 git make oracle-epel-release-el8 && \
+    scl enable gcc-toolset-10 bash
 
 # To compile tn93 within the development environment:
 #   cmake .

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,8 +4,7 @@ FROM oraclelinux:8
 # Set up environment and install dependencies
 RUN yum -y update && \
     yum install -y cmake gcc-c++ gcc-toolset-10 git make oracle-epel-release-el8 && \
-    rm -f CMakeCache.txt && \
-    scl enable gcc-toolset-10 bash
+    echo 'source /opt/rh/gcc-toolset-10/enable' > ~/.bashrc
 
 # To compile tn93 within the development environment:
 #   cmake .


### PR DESCRIPTION
The old `Dockerfile` had an issue where GCC 10 wasn't being used by CMake, which broke OpenMP syntax in the compilation commands. This update fixes the `Dockerfile` to set up GCC 10 properly such that CMake is able to use it