### PR TITLE
Removed duplicate entry for 'S' ambiguity in resolutionsCount

### DIFF
--- a/src/tn93_shared.cc
+++ b/src/tn93_shared.cc
@@ -129,7 +129,6 @@ const  double   resolutionsCount[] = { 1.f,
   1./2.f, // R
   1./2.f, // Y
   1./2.f, // S
-  1./2.f, // S
   1./2.f, // W
   1./2.f, // K
   1./2.f, // M


### PR DESCRIPTION
In tn93_shared.cc, the resolutionsCount array has a duplicate element for the "S" ambiguity. After removing this duplicate, the program is agreeing again with other implementations of TN93. 