### PR TITLE
Add seqdiff to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,4 @@ tn93
 validate_fasta
 tn93-cluster
 fasta_diff
+seqdiff


### PR DESCRIPTION
I just tried cloning and compiling, and it produced an executable called `seqdiff` that is not in the `.gitignore`. This PR adds it to the `.gitignore`